### PR TITLE
[codex] Add ROCm backend support for RDNA GPUs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ ENV/
 # ml-sharp (auto-cloned)
 ml-sharp/
 
+# Local ROCm wheel/download cache
+.rocm-wheels/
+.tmp-rocm-pip/
+
 # User data - DO NOT UPLOAD
 inputs/
 inputs*/

--- a/README.en.md
+++ b/README.en.md
@@ -153,7 +153,7 @@ No need to install apps on every device. Run Sharp GUI on one computer, and any 
 | **📱 Mobile Optimized**    | Phones / tablets get gyroscope controls (iOS-style indicator ball), virtual joystick, touch gestures, and a drawer-style sidebar.                                        |
 | **🥽 VR/AR Preview**       | WebXR VR mode + AR Passthrough on Quest 3/Pro and similar headsets, with controller / touch input.                                                                       |
 | **📤 One-Click Share**     | Export a standalone HTML file powered by Spark 2.0; the compact SPZ payload is embedded by default, double-click to open anywhere.                                       |
-| **🎮 GPU Acceleration**    | Auto-detects NVIDIA GPUs and matches a CUDA-enabled PyTorch (cu118 / cu126 / cu128) for noticeably faster inference.                                                     |
+| **🎮 GPU Acceleration**    | Auto-detects NVIDIA CUDA and supported AMD ROCm/RDNA GPUs (including RX 9070 XT / RDNA4) for noticeably faster inference.                                                 |
 | **🔄 Auto-Update**         | One-click update to the latest release with a pre-release channel; preserves `inputs/` `outputs/` `config.json` and other user data.                                     |
 | **🔐 Security & Privacy**  | Fully local data, one-click self-signed SSL, optional LAN access gate (HttpOnly cookie + access code + brute-force backoff).                                             |
 | **🚀 One-Click Deploy**    | Auto-configures Python / Git, installs deps, pre-downloads models, generates HTTPS certs, and shows skeleton progress. Ready out of the box.                             |
@@ -259,15 +259,21 @@ Built with Apple Human Interface Guidelines for a premium feel:
 | **macOS Apple Silicon**     | ✅ MPS            | ✅ Verified   |
 | **Windows x86_64**          | ✅ CPU            | ✅ Verified   |
 | **Windows x86_64 + NVIDIA** | ✅ CUDA           | ✅ Verified   |
+| **Windows x86_64 + AMD RDNA4** | ✅ ROCm/HIP    | ❓ Unverified |
 | **Linux x86_64**            | ✅ CPU            | ✅ Verified   |
 | **Linux x86_64 + NVIDIA**   | ✅ CUDA           | ❓ Unverified |
+| **Linux x86_64 + AMD RDNA4** | ✅ ROCm/HIP     | ❓ Unverified |
 | **macOS Intel**             | ✅ CPU            | ❓ Unverified |
 
-> 🚀 **NVIDIA GPU recommended**: 3D Gaussian Splatting inference is compute-heavy. CUDA typically delivers **multiple-x to ~10x** speedups over pure CPU, with a noticeably better experience.
+> 🚀 **Dedicated GPU recommended**: 3D Gaussian Splatting inference is compute-heavy. CUDA and ROCm/HIP typically deliver **multiple-x to ~10x** speedups over pure CPU, with a noticeably better experience.
 >
 > 💡 **CPU-only still works**: inference runs fine without a GPU, just slower per image. Apple Silicon users get a near-GPU experience via the MPS backend.
 >
-> 🛠️ **Zero manual setup**: when an NVIDIA GPU is present, the install script detects your driver and installs the matching CUDA-enabled PyTorch (cu118 / cu126 / cu128).
+> 🛠️ **Zero manual setup**: when an NVIDIA GPU is present, the install script detects your driver and installs the matching CUDA-enabled PyTorch (cu126 / cu128). When a supported AMD Radeon RDNA GPU is detected, it installs ROCm/HIP PyTorch and still passes `--device cuda` to ml-sharp because PyTorch ROCm exposes AMD GPUs through the `torch.cuda` namespace.
+>
+> 🧩 **AMD RDNA4 target**: RX 9070 XT / Radeon AI PRO R9700-class RDNA4 cards are treated as ROCm candidates. On Windows, ROCm PyTorch currently requires Python 3.12; set `SHARP_TORCH_BACKEND=rocm` to force a ROCm install attempt if auto-detection misses your card, and `SHARP_DEVICE=rocm` to require a HIP runtime at launch.
+>
+> 🌏 **Mainland network environments**: install scripts default to the Tsinghua PyPI mirror for normal Python dependencies and prefer `hf-mirror.com` for the model download. Set `SHARP_USE_CHINA_MIRROR=0` to disable this, or set `SHARP_PIP_INDEX_URL` to use another PyPI-compatible mirror.
 >
 > 👉 Unverified platforms should theoretically work. Report issues on [GitHub Issues](https://github.com/lueluelue12138/sharp-gui/issues).
 
@@ -321,7 +327,7 @@ The install script automatically handles all setup steps, no manual configuratio
 
 - 🐍 **Detect/Install Python** - Auto-finds compatible version (3.10~3.13), auto-installs if missing (Windows)
 - 📦 **Detect/Install Git** - Auto-installs if missing (Windows)
-- 🎮 **Detect NVIDIA GPU** - Auto-installs the CUDA-enabled PyTorch that matches your driver (cu118 / cu126 / cu128)
+- 🎮 **Detect GPU backend** - Auto-installs CUDA PyTorch for NVIDIA GPUs or ROCm/HIP PyTorch for supported AMD RDNA GPUs
 - 🧩 **Install Dependencies** - Creates virtual environment, installs ml-sharp core and GUI deps
 - 📥 **Pre-download Model** - Downloads inference model (~500MB) during install, no wait on first run
 - 🔐 **Generate HTTPS Certificate** - Auto-generates self-signed certificate for secure LAN access
@@ -523,7 +529,7 @@ sharp-gui/
 │   ├── 📄 generate_cert.py   # SSL certificate generator
 │   ├── 📄 download_model.py  # Model downloader
 │   ├── 📄 detect_cuda.py     # CUDA version detection
-│   ├── 📄 install_torch.py   # Smart PyTorch + CUDA installer / verifier
+│   ├── 📄 install_torch.py   # Smart PyTorch + CUDA / ROCm installer / verifier
 │   └── 📄 update.py          # Auto-update core logic
 ├── 📁 frontend/              # React modern frontend (v1.0.0+)
 ├── 📁 templates/             # Original single-file frontend (Legacy)

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ iOS 26 的"空间照片"带来了令人惊艳的沉浸式体验，但目前仅�
 | **📱 移动端优化**   | 完美适配手机/平板，陀螺仪体感控制（iOS 风格指示球反馈）、虚拟摇杆、触摸手势、抽屉式侧边栏                                                        |
 | **🥽 VR/AR 预览**   | WebXR VR 模式 + AR 透视模式 (Passthrough)，Quest 3/Pro 等头显沉浸式体验，手柄摇杆 + AR 触摸手势                                                   |
 | **📤 零门槛分享**   | 一键导出为 Spark 2.0 版独立 HTML 文件，默认嵌入 SPZ 紧凑模型，双击即可在任何浏览器打开                                                            |
-| **🎮 GPU 加速**     | 自动检测 NVIDIA GPU，智能匹配 CUDA 版本的 PyTorch（cu118 / cu126 / cu128），显著加速推理                                                          |
+| **🎮 GPU 加速**     | 自动检测 NVIDIA CUDA 与受支持的 AMD ROCm/RDNA GPU（含 RX 9070 XT / RDNA4），显著加速推理                                                          |
 | **🔄 自动更新**     | 一键检测最新版本并更新，支持 pre-release 通道，保留 `inputs/` `outputs/` `config.json` 等用户数据                                                |
 | **🔐 安全与隐私**   | 数据完全本地化、自签名 SSL 一键生成、可选局域网门禁（HttpOnly Cookie + 访问码 + 抗暴力猜测）                                                      |
 | **🚀 一键部署运行** | 自动配置 Python/Git 环境、下载依赖、预下载模型、生成 HTTPS 证书、骨架屏加载进度，开箱即用                                                        |
@@ -260,15 +260,21 @@ iOS 26 的"空间照片"带来了令人惊艳的沉浸式体验，但目前仅�
 | **macOS Apple Silicon**     | ✅ MPS    | ✅ 已验证 |
 | **Windows x86_64**          | ✅ CPU    | ✅ 已验证 |
 | **Windows x86_64 + NVIDIA** | ✅ CUDA   | ✅ 已验证 |
+| **Windows x86_64 + AMD RDNA4** | ✅ ROCm/HIP | ❓ 未验证 |
 | **Linux x86_64**            | ✅ CPU    | ✅ 已验证 |
 | **Linux x86_64 + NVIDIA**   | ✅ CUDA   | ❓ 未验证 |
+| **Linux x86_64 + AMD RDNA4** | ✅ ROCm/HIP | ❓ 未验证 |
 | **macOS Intel**             | ✅ CPU    | ❓ 未验证 |
 
-> 🚀 **推荐使用 NVIDIA GPU**：3D 高斯溅射推理是计算密集型任务，CUDA 加速通常比纯 CPU 快 **数倍到十数倍**，体验差距明显。
+> 🚀 **推荐使用独立 GPU**：3D 高斯溅射推理是计算密集型任务，CUDA 与 ROCm/HIP 加速通常比纯 CPU 快 **数倍到十数倍**，体验差距明显。
 >
 > 💡 **没有 GPU 也能跑**：纯 CPU 环境下推理也能完成，只是单张图片生成耗时更长；Apple Silicon 用户可享受 MPS 后端的近 GPU 体验。
 >
-> 🛠️ **零手动配置**：有 NVIDIA GPU 时，安装脚本会自动检测驱动并匹配对应的 PyTorch CUDA 版本（cu118 / cu126 / cu128）。
+> 🛠️ **零手动配置**：有 NVIDIA GPU 时，安装脚本会自动检测驱动并匹配对应的 PyTorch CUDA 版本（cu126 / cu128）；检测到受支持的 AMD Radeon RDNA GPU 时，会安装 ROCm/HIP PyTorch。由于 PyTorch ROCm 也通过 `torch.cuda` 命名空间暴露 AMD GPU，Sharp GUI 仍会向 ml-sharp 传入 `--device cuda`。
+>
+> 🧩 **AMD RDNA4 目标**：RX 9070 XT / Radeon AI PRO R9700 级别 RDNA4 显卡会被视为 ROCm 候选。Windows 下 ROCm PyTorch 当前要求 Python 3.12；如果自动检测漏掉显卡，可设置 `SHARP_TORCH_BACKEND=rocm` 强制尝试 ROCm 安装，设置 `SHARP_DEVICE=rocm` 可在启动时强制要求 HIP 运行时可用。
+>
+> 🌏 **国内网络环境**：安装脚本默认使用清华 PyPI 镜像安装普通 Python 依赖，并优先尝试 `hf-mirror.com` 下载模型；如需关闭可设置 `SHARP_USE_CHINA_MIRROR=0`，如需自定义 PyPI 镜像可设置 `SHARP_PIP_INDEX_URL`。
 >
 > 👉 未验证平台理论上可正常工作，如遇问题欢迎在 [Issues](https://github.com/lueluelue12138/sharp-gui/issues) 反馈。
 
@@ -322,7 +328,7 @@ install.bat       # Windows
 
 - 🐍 **检测/安装 Python** - 自动查找兼容版本 (3.10~3.13)，缺失时自动安装 (Windows)
 - 📦 **检测/安装 Git** - 缺失时自动安装 (Windows)
-- 🎮 **检测 NVIDIA GPU** - 有 GPU 时自动安装匹配驱动的 CUDA 版 PyTorch（cu118 / cu126 / cu128）
+- 🎮 **检测 GPU 后端** - 为 NVIDIA GPU 自动安装 CUDA PyTorch，为受支持的 AMD RDNA GPU 自动安装 ROCm/HIP PyTorch
 - 🧩 **安装依赖** - 创建虚拟环境，安装 ml-sharp 核心和 GUI 依赖
 - 📥 **预下载模型** - 安装阶段即下载推理模型 (~500MB)，避免首次运行等待
 - 🔐 **生成 HTTPS 证书** - 自动生成自签名证书，支持局域网安全访问
@@ -524,7 +530,7 @@ sharp-gui/
 │   ├── 📄 generate_cert.py   # SSL 证书生成工具
 │   ├── 📄 download_model.py  # 模型下载工具
 │   ├── 📄 detect_cuda.py     # CUDA 版本检测
-│   ├── 📄 install_torch.py   # PyTorch + CUDA 智能安装与校验
+│   ├── 📄 install_torch.py   # PyTorch + CUDA / ROCm 智能安装与校验
 │   └── 📄 update.py          # 自动更新核心逻辑
 ├── 📁 frontend/              # React 现代前端 (v1.0.0+)
 ├── 📁 templates/             # 原始单文件前端 (Legacy)

--- a/app.py
+++ b/app.py
@@ -1234,11 +1234,48 @@ TASK_RETENTION_SECONDS = 3600  # 已完成任务保留1小时
 CLEANUP_INTERVAL = 300  # 每5分钟清理一次
 
 
+def verify_torch_cuda_device(require_hip=False):
+    """Verify the torch CUDA namespace can execute CUDA or ROCm kernels."""
+    try:
+        import torch
+    except Exception as exc:
+        return False, f"Unable to import torch: {exc}"
+
+    torch_version = getattr(torch, "version", None)
+    torch_hip = getattr(torch_version, "hip", None)
+    backend = "ROCm" if torch_hip else "CUDA"
+
+    if require_hip and not torch_hip:
+        return False, "SHARP_DEVICE=rocm requested but this PyTorch build has no HIP runtime"
+
+    if not torch.cuda.is_available():
+        return False, f"{backend} is not available through torch.cuda"
+
+    try:
+        x = torch.ones((4, 4), device="cuda")
+        _ = (x @ x).sum().cpu()
+        torch.cuda.synchronize()
+    except Exception as exc:
+        msg = str(exc).splitlines()[0] if str(exc) else repr(exc)
+        return False, f"{backend} is visible but unusable: {msg}"
+
+    return True, f"{backend} via torch.cuda"
+
+
 def select_sharp_device():
     """Return a device that can actually execute kernels."""
     configured = os.environ.get("SHARP_DEVICE", "").strip().lower()
-    if configured in {"cpu", "cuda", "mps"}:
+    if configured in {"cpu", "mps"}:
         return configured
+
+    if configured in {"cuda", "rocm"}:
+        ok, detail = verify_torch_cuda_device(require_hip=(configured == "rocm"))
+        if ok:
+            if configured == "rocm":
+                print("[INFO] SHARP_DEVICE=rocm maps to ml-sharp --device cuda (ROCm/HIP)")
+            return "cuda"
+        print(f"[WARN] {detail}, falling back to CPU")
+        return "cpu"
 
     try:
         import torch
@@ -1246,16 +1283,12 @@ def select_sharp_device():
         print(f"[WARN] Unable to import torch, falling back to CPU: {exc}")
         return "cpu"
 
-    if torch.cuda.is_available():
-        try:
-            x = torch.ones((4, 4), device="cuda")
-            _ = (x @ x).sum().cpu()
-            torch.cuda.synchronize()
-            return "cuda"
-        except Exception as exc:
-            msg = str(exc).splitlines()[0] if str(exc) else repr(exc)
-            print(f"[WARN] CUDA is visible but unusable, falling back to CPU: {msg}")
-            return "cpu"
+    ok, detail = verify_torch_cuda_device()
+    if ok:
+        print(f"[INFO] Using {detail}")
+        return "cuda"
+    if "not available" not in detail:
+        print(f"[WARN] {detail}, falling back to CPU")
 
     if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
         return "mps"

--- a/install.bat
+++ b/install.bat
@@ -22,11 +22,31 @@ set GIT_INSTALL_VERSION=2.47.1
 REM PYTHON_CMD will hold the final python command to use
 set "PYTHON_CMD=python"
 
+REM Mainland-friendly mirrors. Set SHARP_USE_CHINA_MIRROR=0 to disable, or
+REM set SHARP_PIP_INDEX_URL to your preferred PyPI-compatible mirror.
+if not defined SHARP_USE_CHINA_MIRROR set SHARP_USE_CHINA_MIRROR=1
+if "%SHARP_USE_CHINA_MIRROR%"=="1" (
+    if not defined SHARP_PIP_INDEX_URL set "SHARP_PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple"
+    set "PIP_INDEX_URL=%SHARP_PIP_INDEX_URL%"
+    set "PIP_TRUSTED_HOST=pypi.tuna.tsinghua.edu.cn mirrors.aliyun.com pypi.org files.pythonhosted.org"
+    set "PIP_DISABLE_PIP_VERSION_CHECK=1"
+    if not defined SHARP_MODEL_SOURCE set "SHARP_MODEL_SOURCE=china"
+    echo [INFO] Using PyPI mirror: %PIP_INDEX_URL%
+)
+
 REM Check if winget is available
 set HAS_WINGET=false
 where winget >nul 2>&1
 if %ERRORLEVEL% equ 0 (
     set HAS_WINGET=true
+)
+
+REM Detect AMD ROCm candidates before Python selection. Windows ROCm PyTorch
+REM wheels currently require Python 3.12, so RDNA GPUs should not use 3.13 venvs.
+set HAS_ROCM_CANDIDATE=false
+for /f "usebackq delims=" %%i in (`powershell -NoProfile -Command "$n=(Get-CimInstance Win32_VideoController).Name -join '; '; if ($n -match 'Radeon RX 90|Radeon AI PRO R9700|Radeon PRO AI R9700|Radeon RX 79|Radeon PRO W7') { $n }" 2^>nul`) do (
+    set HAS_ROCM_CANDIDATE=true
+    echo [OK] Found AMD ROCm candidate GPU: %%i
 )
 
 REM ============================================================
@@ -180,6 +200,21 @@ for /f "tokens=1,2 delims=." %%a in ("%PYTHON_VERSION%") do (
     set PYTHON_MINOR=%%b
 )
 
+if "!HAS_ROCM_CANDIDATE!"=="true" if not "!PYTHON_MINOR!"=="12" (
+    echo.
+    echo [提示] 检测到 AMD ROCm 候选 GPU，Windows ROCm PyTorch 需要 Python 3.12
+    where py >nul 2>&1
+    if !ERRORLEVEL! equ 0 (
+        py -3.12 --version >nul 2>&1
+        if !ERRORLEVEL! equ 0 (
+            set "PYTHON_CMD=py -3.12"
+            for /f "tokens=2" %%i in ('py -3.12 --version 2^>^&1') do echo [OK] ROCm 路径将使用 Python %%i
+            goto :python_version_ok
+        )
+    )
+    goto :need_python_312
+)
+
 REM Check: Python version must be 3.10 ~ 3.13
 set VERSION_OK=false
 if %PYTHON_MAJOR% EQU 3 (
@@ -220,6 +255,7 @@ if !ERRORLEVEL! equ 0 (
 )
 
 REM No compatible version found, need to install 3.12
+:need_python_312
 echo [警告] 未找到兼容的 Python 版本
 echo.
 echo   当前系统的 Python %PYTHON_VERSION% 版本过新，部分依赖不支持
@@ -557,7 +593,7 @@ call "%VENV_DIR%\Scripts\activate.bat"
 python -m pip install --upgrade pip
 
 REM Install ml-sharp requirements first. Its requirements.txt pins torch,
-REM so the final CUDA/CPU PyTorch build is selected and verified afterward.
+REM so the final CUDA/ROCm/CPU PyTorch build is selected and verified afterward.
 
 :install_sharp_core_deps
 echo 安装 Sharp 核心 (这可能需要几分钟)...
@@ -576,11 +612,11 @@ if !ERRORLEVEL! neq 0 (
 cd /d "%SCRIPT_DIR%"
 
 echo.
-echo 检查并修复 PyTorch / CUDA 运行环境...
+echo 检查并修复 PyTorch / CUDA / ROCm 运行环境...
 python "%SCRIPT_DIR%tools\install_torch.py"
 if !ERRORLEVEL! neq 0 (
     echo.
-    echo [错误] PyTorch 安装或 CUDA kernel 验证失败
+    echo [错误] PyTorch 安装或 CUDA/ROCm kernel 验证失败
     pause
     exit /b 1
 )
@@ -643,7 +679,7 @@ python -c "import torch; print(f'PyTorch: {torch.__version__}')"
 python -c "import flask; print(f'Flask: {flask.__version__}')"
 
 REM 显示 GPU 状态
-python -c "import torch; cuda=torch.cuda.is_available(); mps=hasattr(torch.backends,'mps') and torch.backends.mps.is_available(); device='CUDA (NVIDIA GPU)' if cuda else ('MPS (Apple GPU)' if mps else 'CPU'); print(f'推理设备: {device}')"
+python -c "import torch; cuda=torch.cuda.is_available(); hip=getattr(torch.version,'hip',None); mps=hasattr(torch.backends,'mps') and torch.backends.mps.is_available(); device='ROCm (AMD GPU)' if cuda and hip else ('CUDA (NVIDIA GPU)' if cuda else ('MPS (Apple GPU)' if mps else 'CPU')); print(f'推理设备: {device}')"
 
 echo [OK] 安装测试通过
 

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,15 @@ print_error() { echo -e "${RED}✗${NC} $1"; }
 SHARP_REPO="https://github.com/apple/ml-sharp.git"
 SHARP_DIR="ml-sharp"
 
+if [ "${SHARP_USE_CHINA_MIRROR:-1}" != "0" ]; then
+    export SHARP_PIP_INDEX_URL="${SHARP_PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}"
+    export PIP_INDEX_URL="$SHARP_PIP_INDEX_URL"
+    export PIP_TRUSTED_HOST="${PIP_TRUSTED_HOST:-pypi.tuna.tsinghua.edu.cn mirrors.aliyun.com pypi.org files.pythonhosted.org}"
+    export PIP_DISABLE_PIP_VERSION_CHECK=1
+    export SHARP_MODEL_SOURCE="${SHARP_MODEL_SOURCE:-china}"
+    echo "Using PyPI mirror: $PIP_INDEX_URL"
+fi
+
 # 获取脚本目录
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
@@ -269,6 +278,12 @@ install_dependencies() {
             fi
         fi
     fi
+
+    print_step "检查 PyTorch CUDA / ROCm 运行环境..."
+    if ! python "$SCRIPT_DIR/tools/install_torch.py"; then
+        print_error "PyTorch CUDA / ROCm 运行环境验证失败"
+        exit 1
+    fi
     
     # 安装 GUI 依赖
     print_step "安装 GUI 依赖..."
@@ -357,7 +372,7 @@ test_installation() {
     }
     
     # 显示 GPU 状态
-    python -c "import torch; cuda=torch.cuda.is_available(); mps=hasattr(torch.backends,'mps') and torch.backends.mps.is_available(); device='CUDA (NVIDIA GPU)' if cuda else ('MPS (Apple GPU)' if mps else 'CPU'); print(f'推理设备: {device}')"
+    python -c "import torch; cuda=torch.cuda.is_available(); hip=getattr(torch.version,'hip',None); mps=hasattr(torch.backends,'mps') and torch.backends.mps.is_available(); device='ROCm (AMD GPU)' if cuda and hip else ('CUDA (NVIDIA GPU)' if cuda else ('MPS (Apple GPU)' if mps else 'CPU')); print(f'推理设备: {device}')"
     
     print_success "安装测试通过"
 }

--- a/tests/test_download_model.py
+++ b/tests/test_download_model.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from tools import download_model
+
+
+class DownloadModelSourceTests(unittest.TestCase):
+    def test_default_source_order_keeps_huggingface_first(self):
+        with patch.dict(os.environ, {}, clear=True):
+            sources = download_model.ordered_sources()
+
+        self.assertEqual(sources[0][0], "HuggingFace")
+
+    def test_china_mirror_prefers_hf_mirror(self):
+        with patch.dict(os.environ, {"SHARP_MODEL_SOURCE": "china"}, clear=True):
+            sources = download_model.ordered_sources()
+
+        self.assertIn("hf-mirror.com", sources[0][1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_torch.py
+++ b/tests/test_install_torch.py
@@ -1,0 +1,89 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from tools import install_torch
+
+
+class InstallTorchBackendTests(unittest.TestCase):
+    def test_choose_cuda_index_prefers_newest_supported_runtime(self):
+        self.assertEqual(install_torch.choose_cuda_index((12, 8)), "cu128")
+        self.assertEqual(install_torch.choose_cuda_index((12, 6)), "cu126")
+        self.assertIsNone(install_torch.choose_cuda_index((12, 5)))
+
+    def test_rdna4_radeon_names_are_rocm_candidates(self):
+        names = ["AMD Radeon RX 9070 XT"]
+
+        self.assertTrue(install_torch.is_rocm_supported_gpu(names))
+
+    def test_rdna4_gfx_archs_are_rocm_candidates(self):
+        names = ["Name: gfx1201"]
+
+        self.assertTrue(install_torch.is_rocm_supported_gpu(names))
+
+    def test_generic_integrated_amd_gpu_is_not_auto_enabled(self):
+        names = ["AMD Radeon Graphics"]
+
+        self.assertFalse(install_torch.is_rocm_supported_gpu(names))
+
+    def test_rocm_wheel_urls_match_supported_python_versions(self):
+        windows_urls = install_torch.rocm_wheel_urls("Windows", (3, 12))
+
+        self.assertTrue(
+            windows_urls[0].endswith("rocm_sdk_core-7.2.1-py3-none-win_amd64.whl")
+        )
+        self.assertFalse(any(url.endswith(".tar.gz") for url in windows_urls))
+        self.assertTrue(
+            install_torch.rocm_meta_package_url("Windows", (3, 12)).endswith(
+                "rocm-7.2.1.tar.gz"
+            )
+        )
+        self.assertIsNone(install_torch.rocm_meta_package_url("Windows", (3, 11)))
+        self.assertEqual(install_torch.rocm_wheel_urls("Windows", (3, 11)), ())
+        self.assertTrue(
+            install_torch.rocm_wheel_urls("Linux", (3, 12))[0].endswith(
+                "cp312-cp312-linux_x86_64.whl"
+            )
+        )
+        self.assertEqual(install_torch.rocm_wheel_urls("Linux", (3, 11)), ())
+
+    def test_rocm_pip_environment_bypasses_radeon_repo_proxy(self):
+        env = install_torch.rocm_pip_environment(
+            ("https://repo.radeon.com/rocm/windows/example.whl",),
+            {"NO_PROXY": "localhost"},
+        )
+
+        self.assertEqual(env["NO_PROXY"], "localhost,repo.radeon.com")
+        self.assertEqual(env["no_proxy"], env["NO_PROXY"])
+
+    def test_rocm_pip_environment_can_keep_system_proxy(self):
+        env = install_torch.rocm_pip_environment(
+            ("https://repo.radeon.com/rocm/windows/example.whl",),
+            {
+                "NO_PROXY": "localhost",
+                "SHARP_TORCH_USE_SYSTEM_PROXY": "1",
+            },
+        )
+
+        self.assertEqual(env["NO_PROXY"], "localhost")
+        self.assertNotIn("no_proxy", env)
+
+    def test_rocm_package_specs_prefer_local_wheels(self):
+        url = "https://repo.radeon.com/rocm/windows/torch-2.9.1%2Brocm7.2.1.whl"
+        with TemporaryDirectory() as tmp:
+            local = Path(tmp) / "torch-2.9.1+rocm7.2.1.whl"
+            local.touch()
+
+            specs = install_torch.rocm_package_specs((url,), tmp)
+
+        self.assertEqual(specs, (str(local),))
+
+    def test_rocm_import_compat_source_is_lazy(self):
+        top_level = install_torch.ROCM_COMPAT_SOURCE.split("class ", 1)[0]
+
+        self.assertNotIn("import torch", top_level)
+        self.assertIn("sys.meta_path.insert", install_torch.ROCM_COMPAT_SOURCE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/download_model.py
+++ b/tools/download_model.py
@@ -22,6 +22,24 @@ SOURCES = [
 ]
 
 
+def ordered_sources():
+    """Return model sources, optionally preferring mainland-friendly mirrors."""
+    preferred = os.environ.get("SHARP_MODEL_SOURCE", "").strip().lower()
+    use_china = os.environ.get("SHARP_USE_CHINA_MIRROR", "").strip() == "1"
+    if preferred not in {"china", "mirror", "hf-mirror"} and not use_china:
+        return SOURCES
+
+    def source_rank(source):
+        url = source[1]
+        if "hf-mirror.com" in url:
+            return 0
+        if "ml-site.cdn-apple.com" in url:
+            return 1
+        return 2
+
+    return sorted(SOURCES, key=source_rank)
+
+
 def get_model_path():
     cache_dir = os.path.join(
         os.path.expanduser("~"), ".cache", "torch", "hub", "checkpoints"
@@ -120,7 +138,7 @@ def main():
 
     tmp_path = model_path + ".downloading"
 
-    for name, url in SOURCES:
+    for name, url in ordered_sources():
         print(f"[{name}] {url}")
         try:
             # Clean up any previous partial download

--- a/tools/install_torch.py
+++ b/tools/install_torch.py
@@ -3,42 +3,270 @@
 
 The ml-sharp requirements pin torch/torchvision versions. On Windows, pip may
 install a CPU build first, and older CUDA wheels can appear usable while missing
-kernels for new NVIDIA architectures such as sm_120. This helper runs after the
-core requirements and makes the final torch install match the local driver.
+kernels for new NVIDIA architectures such as sm_120. AMD ROCm wheels also use
+the torch.cuda namespace, so this helper runs after the core requirements and
+makes the final torch install match the local driver.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+import platform
 import re
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
+import site
+from urllib.parse import unquote
+from urllib.parse import urlparse
 
 
 TORCH_VERSION = "2.8.0"
 TORCHVISION_VERSION = "0.23.0"
+ROCM_VERSION = "7.2.1"
 CUDA_CHOICES = (
     ((12, 8), "cu128"),
     ((12, 6), "cu126"),
 )
+ROCM_GPU_PATTERNS = (
+    "radeon rx 9070",
+    "radeon rx 9060",
+    "radeon ai pro r9700",
+    "radeon pro ai r9700",
+    "radeon pro w7900",
+    "radeon pro w7800",
+    "radeon pro w7700",
+    "radeon rx 7900",
+    "radeon rx 7800",
+    "radeon rx 7700",
+)
+ROCM_ARCH_PATTERNS = ("gfx1201", "gfx1200", "gfx1101", "gfx1100")
+ROCM_PIP_NO_PROXY_HOSTS = ("repo.radeon.com",)
+ROCM_COMPAT_MODULE = "sharp_rocm_import_compat"
+ROCM_COMPAT_PTH = "sharp_rocm_import_compat.pth"
+ROCM_COMPAT_SOURCE = r'''
+"""Lazy import compatibility for Windows ROCm PyTorch.
+
+Some Windows ROCm PyTorch builds expose HIP devices through torch.cuda but ship
+without torch.distributed support. gsplat imports torch.distributed.nn.functional
+at module import time even for single-GPU inference, so provide a narrow stub only
+for that module and only when a HIP build reports distributed as unavailable.
+"""
+
+from __future__ import annotations
+
+import importlib.abc
+import importlib.machinery
+import sys
+
+
+TARGET = "torch.distributed.nn.functional"
+
+
+def _unavailable(*args, **kwargs):
+    raise RuntimeError("torch.distributed is unavailable in this ROCm PyTorch build")
+
+
+class _RocmDistributedFunctionalLoader(importlib.abc.Loader):
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        for name in (
+            "all_gather",
+            "all_reduce",
+            "all_to_all",
+            "all_to_all_single",
+            "broadcast",
+            "reduce_scatter",
+        ):
+            setattr(module, name, _unavailable)
+
+
+class _RocmDistributedFunctionalFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname != TARGET:
+            return None
+
+        try:
+            import torch
+            import torch.distributed as dist
+        except Exception:
+            return None
+
+        torch_version = getattr(torch, "version", None)
+        if not getattr(torch_version, "hip", None):
+            return None
+
+        try:
+            if dist.is_available():
+                return None
+        except Exception:
+            pass
+
+        return importlib.machinery.ModuleSpec(
+            fullname,
+            _RocmDistributedFunctionalLoader(),
+            origin="sharp-rocm-compat",
+        )
+
+
+if not any(isinstance(finder, _RocmDistributedFunctionalFinder) for finder in sys.meta_path):
+    sys.meta_path.insert(0, _RocmDistributedFunctionalFinder())
+'''
+ROCM_WINDOWS_META_PACKAGE = (
+    f"https://repo.radeon.com/rocm/windows/rocm-rel-{ROCM_VERSION}/rocm-{ROCM_VERSION}.tar.gz"
+)
+ROCM_WINDOWS_PACKAGES = (
+    f"https://repo.radeon.com/rocm/windows/rocm-rel-{ROCM_VERSION}/"
+    f"rocm_sdk_core-{ROCM_VERSION}-py3-none-win_amd64.whl",
+    f"https://repo.radeon.com/rocm/windows/rocm-rel-{ROCM_VERSION}/"
+    f"rocm_sdk_devel-{ROCM_VERSION}-py3-none-win_amd64.whl",
+    f"https://repo.radeon.com/rocm/windows/rocm-rel-{ROCM_VERSION}/"
+    f"rocm_sdk_libraries_custom-{ROCM_VERSION}-py3-none-win_amd64.whl",
+    f"https://repo.radeon.com/rocm/windows/rocm-rel-{ROCM_VERSION}/"
+    f"torch-2.9.1%2Brocm{ROCM_VERSION}-cp312-cp312-win_amd64.whl",
+    f"https://repo.radeon.com/rocm/windows/rocm-rel-{ROCM_VERSION}/"
+    f"torchaudio-2.9.1%2Brocm{ROCM_VERSION}-cp312-cp312-win_amd64.whl",
+    f"https://repo.radeon.com/rocm/windows/rocm-rel-{ROCM_VERSION}/"
+    f"torchvision-0.24.1%2Brocm{ROCM_VERSION}-cp312-cp312-win_amd64.whl",
+)
+ROCM_LINUX_PACKAGES = {
+    (3, 10): (
+        f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{ROCM_VERSION}/"
+        f"torch-2.9.1%2Brocm{ROCM_VERSION}.lw.gitff65f5bc-cp310-cp310-linux_x86_64.whl",
+        f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{ROCM_VERSION}/"
+        f"torchvision-0.24.0%2Brocm{ROCM_VERSION}.gitb919bd0c-cp310-cp310-linux_x86_64.whl",
+        f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{ROCM_VERSION}/"
+        f"triton-3.5.1%2Brocm{ROCM_VERSION}.gita272dfa8-cp310-cp310-linux_x86_64.whl",
+        f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{ROCM_VERSION}/"
+        f"torchaudio-2.9.0%2Brocm{ROCM_VERSION}.gite3c6ee2b-cp310-cp310-linux_x86_64.whl",
+    ),
+    (3, 12): (
+        f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{ROCM_VERSION}/"
+        f"torch-2.9.1%2Brocm{ROCM_VERSION}.lw.gitff65f5bc-cp312-cp312-linux_x86_64.whl",
+        f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{ROCM_VERSION}/"
+        f"torchvision-0.24.0%2Brocm{ROCM_VERSION}.gitb919bd0c-cp312-cp312-linux_x86_64.whl",
+        f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{ROCM_VERSION}/"
+        f"triton-3.5.1%2Brocm{ROCM_VERSION}.gita272dfa8-cp312-cp312-linux_x86_64.whl",
+        f"https://repo.radeon.com/rocm/manylinux/rocm-rel-{ROCM_VERSION}/"
+        f"torchaudio-2.9.0%2Brocm{ROCM_VERSION}.gite3c6ee2b-cp312-cp312-linux_x86_64.whl",
+    ),
+}
 
 
 @dataclass(frozen=True)
 class VerifyResult:
     ok: bool
     detail: str
+    backend: str = "unknown"
     version: str | None = None
     cuda: str | None = None
+    hip: str | None = None
     device_name: str | None = None
     capability: tuple[int, int] | None = None
     arch_list: tuple[str, ...] = ()
 
 
-def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+def run(
+    cmd: list[str],
+    *,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     print("+ " + " ".join(cmd), flush=True)
-    return subprocess.run(cmd, check=check, text=True)
+    return subprocess.run(cmd, check=check, text=True, env=env)
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _pip_network_flags() -> list[str]:
+    return [
+        "--timeout",
+        os.environ.get("SHARP_TORCH_PIP_TIMEOUT", "120"),
+        "--retries",
+        os.environ.get("SHARP_TORCH_PIP_RETRIES", "2"),
+    ]
+
+
+def _merge_no_proxy(existing: str | None, hosts: tuple[str, ...]) -> str:
+    entries = [entry.strip() for entry in (existing or "").split(",") if entry.strip()]
+    seen = {entry.lower() for entry in entries}
+    if "*" in seen:
+        return ",".join(entries)
+    for host in hosts:
+        lowered = host.lower()
+        if lowered not in seen:
+            entries.append(host)
+            seen.add(lowered)
+    return ",".join(entries)
+
+
+def rocm_pip_environment(
+    urls: tuple[str, ...], base_env: dict[str, str] | None = None
+) -> dict[str, str]:
+    env = dict(os.environ if base_env is None else base_env)
+    if _truthy(env.get("SHARP_TORCH_USE_SYSTEM_PROXY")):
+        return env
+
+    hosts = tuple(
+        dict.fromkeys(
+            host
+            for host in (
+                urlparse(url).hostname for url in urls
+            )
+            if host in ROCM_PIP_NO_PROXY_HOSTS
+        )
+    )
+    if not hosts:
+        return env
+
+    no_proxy = _merge_no_proxy(env.get("NO_PROXY") or env.get("no_proxy"), hosts)
+    env["NO_PROXY"] = no_proxy
+    env["no_proxy"] = no_proxy
+    return env
+
+
+def _filename_from_url(url: str) -> str:
+    return unquote(urlparse(url).path.rsplit("/", 1)[-1])
+
+
+def rocm_package_specs(
+    urls: tuple[str, ...], wheel_dir: str | os.PathLike[str] | None = None
+) -> tuple[str, ...]:
+    if not wheel_dir:
+        return urls
+
+    directory = Path(wheel_dir)
+    specs: list[str] = []
+    for url in urls:
+        local_path = directory / _filename_from_url(url)
+        specs.append(str(local_path) if local_path.exists() else url)
+    return tuple(specs)
+
+
+def _site_packages_dir() -> Path:
+    candidates = [Path(path) for path in site.getsitepackages()]
+    for path in candidates:
+        if path.name == "site-packages":
+            return path
+    if os.name == "nt":
+        return Path(sys.prefix) / "Lib" / "site-packages"
+    return Path(sys.prefix) / "lib" / f"python{sys.version_info.major}.{sys.version_info.minor}" / "site-packages"
+
+
+def install_rocm_import_compat() -> None:
+    site_packages = _site_packages_dir()
+    site_packages.mkdir(parents=True, exist_ok=True)
+    module_path = site_packages / f"{ROCM_COMPAT_MODULE}.py"
+    pth_path = site_packages / ROCM_COMPAT_PTH
+    module_path.write_text(ROCM_COMPAT_SOURCE.lstrip(), encoding="utf-8")
+    pth_path.write_text(f"import {ROCM_COMPAT_MODULE}\n", encoding="utf-8")
+    print(f"[INFO] Installed ROCm import compatibility hook: {module_path}")
 
 
 def driver_cuda_version() -> tuple[int, int] | None:
@@ -76,21 +304,88 @@ def choose_cuda_index(driver_cuda: tuple[int, int] | None) -> str | None:
     return None
 
 
-def verify_cuda_runtime() -> VerifyResult:
+def amd_gpu_names() -> list[str]:
+    system = platform.system()
+    commands: list[list[str]] = []
+    if system == "Windows":
+        commands.append(
+            [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                "Get-CimInstance Win32_VideoController | ForEach-Object { $_.Name }",
+            ]
+        )
+        commands.append(["wmic", "path", "win32_VideoController", "get", "name"])
+    elif system == "Linux":
+        commands.extend((["rocminfo"], ["rocm-smi", "--showproductname"], ["lspci"]))
+
+    names: list[str] = []
+    for cmd in commands:
+        try:
+            output = subprocess.check_output(
+                cmd, stderr=subprocess.STDOUT, text=True, timeout=20
+            )
+        except Exception:
+            continue
+        for line in output.splitlines():
+            cleaned = line.strip()
+            lowered = cleaned.lower()
+            if "amd" in lowered or "radeon" in lowered or "gfx" in lowered:
+                names.append(cleaned)
+
+    return list(dict.fromkeys(names))
+
+
+def is_rocm_supported_gpu(names: list[str]) -> bool:
+    haystack = "\n".join(names).lower()
+    return any(pattern in haystack for pattern in ROCM_GPU_PATTERNS + ROCM_ARCH_PATTERNS)
+
+
+def rocm_wheel_urls(
+    system: str | None = None,
+    python_version: tuple[int, int] | None = None,
+) -> tuple[str, ...]:
+    system = system or platform.system()
+    python_version = python_version or sys.version_info[:2]
+    if system == "Windows" and python_version == (3, 12):
+        return ROCM_WINDOWS_PACKAGES
+    if system == "Linux":
+        return ROCM_LINUX_PACKAGES.get(python_version, ())
+    return ()
+
+
+def rocm_meta_package_url(
+    system: str | None = None,
+    python_version: tuple[int, int] | None = None,
+) -> str | None:
+    system = system or platform.system()
+    python_version = python_version or sys.version_info[:2]
+    if system == "Windows" and python_version == (3, 12):
+        return ROCM_WINDOWS_META_PACKAGE
+    return None
+
+
+def verify_accelerator_runtime() -> VerifyResult:
     try:
         import torch
     except Exception as exc:
         return VerifyResult(False, f"torch import failed: {exc}")
 
     version = getattr(torch, "__version__", None)
-    torch_cuda = getattr(getattr(torch, "version", None), "cuda", None)
+    torch_version = getattr(torch, "version", None)
+    torch_cuda = getattr(torch_version, "cuda", None)
+    torch_hip = getattr(torch_version, "hip", None)
+    backend = "rocm" if torch_hip else "cuda"
 
     if not torch.cuda.is_available():
         return VerifyResult(
             False,
             "torch.cuda.is_available() is False",
+            backend=backend,
             version=version,
             cuda=torch_cuda,
+            hip=torch_hip,
         )
 
     try:
@@ -105,16 +400,20 @@ def verify_cuda_runtime() -> VerifyResult:
         first_line = str(exc).splitlines()[0] if str(exc) else repr(exc)
         return VerifyResult(
             False,
-            f"CUDA kernel test failed: {first_line}",
+            f"{backend.upper()} kernel test failed: {first_line}",
+            backend=backend,
             version=version,
             cuda=torch_cuda,
+            hip=torch_hip,
         )
 
     return VerifyResult(
         True,
-        "CUDA kernel test passed",
+        f"{backend.upper()} kernel test passed",
+        backend=backend,
         version=version,
         cuda=torch_cuda,
+        hip=torch_hip,
         device_name=device_name,
         capability=capability,
         arch_list=arch_list,
@@ -138,6 +437,7 @@ def pip_install_torch(index_tag: str | None) -> bool:
         "-m",
         "pip",
         "install",
+        *_pip_network_flags(),
         "--force-reinstall",
         "--no-deps",
         f"torch=={TORCH_VERSION}",
@@ -153,6 +453,79 @@ def pip_install_torch(index_tag: str | None) -> bool:
         return False
 
 
+def pip_install_rocm(wheel_dir: str | None = None) -> bool:
+    urls = rocm_wheel_urls()
+    if not urls:
+        print(
+            "[WARN] ROCm PyTorch wheels are only configured for "
+            "Windows Python 3.12 and Linux Python 3.10/3.12."
+        )
+        return False
+
+    package_specs = rocm_package_specs(urls, wheel_dir)
+    meta_url = rocm_meta_package_url()
+    meta_spec = rocm_package_specs((meta_url,), wheel_dir)[0] if meta_url else None
+    local_specs = [spec for spec in package_specs if not spec.startswith(("http://", "https://"))]
+    if local_specs:
+        print(f"[INFO] Using local ROCm wheel directory: {wheel_dir}")
+
+    uninstall_cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "uninstall",
+        "-y",
+        "torch",
+        "torchvision",
+        "triton",
+        "torchaudio",
+        "rocm",
+        "rocm-sdk-core",
+        "rocm-sdk-devel",
+        "rocm-sdk-libraries-custom",
+    ]
+    run(uninstall_cmd, check=False)
+
+    if meta_spec:
+        meta_cmd = [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            *_pip_network_flags(),
+            "--no-cache-dir",
+            "--no-deps",
+            meta_spec,
+        ]
+        try:
+            run(meta_cmd, env=rocm_pip_environment((meta_url,)))
+        except subprocess.CalledProcessError as exc:
+            print(f"[WARN] ROCm meta-package install failed with exit code {exc.returncode}")
+            return False
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        *_pip_network_flags(),
+        "--no-cache-dir",
+        *package_specs,
+    ]
+    env = rocm_pip_environment(urls)
+    if not _truthy(env.get("SHARP_TORCH_USE_SYSTEM_PROXY")):
+        print(
+            "[INFO] ROCm downloads bypass system proxy for repo.radeon.com. "
+            "Set SHARP_TORCH_USE_SYSTEM_PROXY=1 to keep the system proxy."
+        )
+    try:
+        run(cmd, env=env)
+        return True
+    except subprocess.CalledProcessError as exc:
+        print(f"[WARN] ROCm PyTorch install failed with exit code {exc.returncode}")
+        return False
+
+
 def install_cpu_fallback() -> int:
     print("[INFO] Installing CPU PyTorch fallback.")
     if not pip_install_torch(None):
@@ -160,37 +533,90 @@ def install_cpu_fallback() -> int:
     return 0 if verify_torch_import() else 1
 
 
+def print_verified_runtime(result: VerifyResult) -> None:
+    print(
+        f"[OK] {result.backend.upper()} PyTorch verified: "
+        f"torch={result.version}, cuda={result.cuda}, hip={result.hip}, "
+        f"device={result.device_name}, capability={result.capability}, "
+        f"archs={','.join(result.arch_list)}"
+    )
+
+
+def default_backend() -> str:
+    configured = os.environ.get("SHARP_TORCH_BACKEND", "auto").strip().lower()
+    return configured if configured in {"auto", "cuda", "rocm", "cpu"} else "auto"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "cuda", "rocm", "cpu"),
+        default=default_backend(),
+        help="Preferred PyTorch backend. ROCm uses torch.cuda/HIP on AMD GPUs.",
+    )
     parser.add_argument("--check-only", action="store_true")
     parser.add_argument("--cpu-only", action="store_true")
+    parser.add_argument(
+        "--rocm-wheel-dir",
+        default=os.environ.get("SHARP_TORCH_ROCM_WHEEL_DIR"),
+        help="Optional directory containing pre-downloaded ROCm wheels.",
+    )
     args = parser.parse_args()
 
     os.environ.setdefault("PYTHONUTF8", "1")
     os.environ.setdefault("PYTHONIOENCODING", "utf-8")
 
-    if args.cpu_only:
+    if args.cpu_only or args.backend == "cpu":
         return install_cpu_fallback()
 
-    current = verify_cuda_runtime()
-    if current.ok:
-        print(
-            f"[OK] CUDA PyTorch ready: torch={current.version}, "
-            f"cuda={current.cuda}, device={current.device_name}, "
-            f"capability={current.capability}, archs={','.join(current.arch_list)}"
-        )
+    current = verify_accelerator_runtime()
+    if current.ok and args.backend in {"auto", current.backend}:
+        if current.backend == "rocm" and not args.check_only:
+            install_rocm_import_compat()
+        print_verified_runtime(current)
         return 0
 
-    print(f"[INFO] Current PyTorch CUDA check: {current.detail}")
+    print(f"[INFO] Current PyTorch accelerator check: {current.detail}")
     if current.version:
-        print(f"[INFO] Current torch={current.version}, cuda={current.cuda}")
+        print(
+            f"[INFO] Current torch={current.version}, cuda={current.cuda}, hip={current.hip}"
+        )
 
     if args.check_only:
         return 1
 
+    amd_names = amd_gpu_names()
+    wants_rocm = args.backend == "rocm" or (
+        args.backend == "auto" and is_rocm_supported_gpu(amd_names)
+    )
+    if wants_rocm:
+        if amd_names:
+            print("[INFO] AMD ROCm candidate GPU detected: " + "; ".join(amd_names))
+        else:
+            print("[INFO] ROCm backend requested explicitly.")
+        print(f"[INFO] Installing PyTorch ROCm {ROCM_VERSION} for AMD/RDNA GPUs.")
+        if pip_install_rocm(args.rocm_wheel_dir):
+            updated = verify_accelerator_runtime()
+            if updated.ok and updated.backend == "rocm":
+                install_rocm_import_compat()
+                print_verified_runtime(updated)
+                return 0
+            print(f"[WARN] ROCm PyTorch installed but failed verification: {updated.detail}")
+        print("[WARN] Falling back to CPU PyTorch so inference remains functional.")
+        return install_cpu_fallback()
+
     gpu_names = nvidia_gpu_names()
     if not gpu_names:
-        print("[INFO] No NVIDIA GPU detected. Keeping/installing CPU PyTorch.")
+        if amd_names:
+            print(
+                "[INFO] AMD GPU detected but it is not in the ROCm auto-install list: "
+                + "; ".join(amd_names)
+            )
+            print("[INFO] Set SHARP_TORCH_BACKEND=rocm to force a ROCm install attempt.")
+        else:
+            print("[INFO] No NVIDIA or supported AMD ROCm GPU detected.")
+        print("[INFO] Keeping/installing CPU PyTorch.")
         return install_cpu_fallback()
 
     print("[INFO] NVIDIA GPU detected: " + "; ".join(gpu_names))
@@ -213,13 +639,9 @@ def main() -> int:
         print("[WARN] CUDA PyTorch install failed; falling back to CPU.")
         return install_cpu_fallback()
 
-    updated = verify_cuda_runtime()
+    updated = verify_accelerator_runtime()
     if updated.ok:
-        print(
-            f"[OK] CUDA PyTorch verified: torch={updated.version}, "
-            f"cuda={updated.cuda}, device={updated.device_name}, "
-            f"capability={updated.capability}, archs={','.join(updated.arch_list)}"
-        )
+        print_verified_runtime(updated)
         return 0
 
     print(f"[WARN] CUDA PyTorch installed but failed verification: {updated.detail}")


### PR DESCRIPTION
## Summary

Adds an AMD ROCm/HIP install path alongside the existing CUDA/CPU PyTorch selection, with RX 9070 XT / RDNA4-class cards as the primary compatibility target.

- detects supported AMD Radeon RDNA GPUs, including RX 9070 XT / RDNA4-class cards
- prefers Python 3.12 for Windows ROCm installs and installs ROCm PyTorch 7.2.1 wheels
- installs the ROCm meta package with `--no-deps` first, avoiding the ROCm wheel resolver self-dependency loop
- maps `SHARP_DEVICE=rocm` to ml-sharp's `--device cuda`, because PyTorch ROCm exposes HIP devices through `torch.cuda`
- supports pre-downloaded/local ROCm wheels via `SHARP_TORCH_ROCM_WHEEL_DIR` / `--rocm-wheel-dir`
- adds a lazy Windows ROCm import hook for `gsplat`'s `torch.distributed.nn.functional` import path when `torch.distributed` is unavailable; the hook does not import `torch` at Python startup
- defaults install scripts to mainland-friendly PyPI/model mirrors, with `SHARP_USE_CHINA_MIRROR=0` and `SHARP_PIP_INDEX_URL` overrides

## Local validation

On a local AMD Radeon RX 9070 XT:

- `tools/install_torch.py --backend rocm --check-only` passed with `torch=2.9.1+rocm7.2.1`, `hip=7.2.53211-158bd99533`, and device `AMD Radeon RX 9070 XT`
- `sharp --help` passed after installing the lazy ROCm import hook
- `SHARP_DEVICE=rocm` selected `cuda` for ml-sharp, as expected for PyTorch ROCm
- no full `sharp predict` model inference was run in this PR

## Checks

- `py -3.12 -S -m py_compile app.py tools\install_torch.py tools\download_model.py tests\test_install_torch.py tests\test_download_model.py`
- `py -3.12 -S -m unittest discover -s tests -v`
- `git diff --check`
- `bash -n install.sh`
